### PR TITLE
Changed default 'default image' location

### DIFF
--- a/resources/fixtures/config/imageResize.yml
+++ b/resources/fixtures/config/imageResize.yml
@@ -1,2 +1,2 @@
-default-image-path: /cogules/App:Site/images/default.png # Path to default image for resizing, relative to public/web path
+default-image-path: /cogules/Mothership:Site/images/default.jpg # Path to default image for resizing, relative to public/web path
 salt: Masdj9w3jW$W(£$FJsejadhahwd3h8sfeiuh4kf$r0sfefsE))sfhscnaibw883


### PR DESCRIPTION
Changes the path to the default config location to match the default image in the Mothership repo: https://github.com/mothership-ec/mothership/blob/develop/app/site/resources/public/images/default.jpg .

Set up a ms installation wit this default config and check that this image gets pulled through.
